### PR TITLE
Fix crash for group chats (quick and dirty fix sorry)

### DIFF
--- a/telegram/telegram_cli/interface.c
+++ b/telegram/telegram_cli/interface.c
@@ -1197,10 +1197,10 @@ void print_date_full (long t) {
 int our_id;
 
 void print_service_message (struct message *M) {
+  return;
   assert (M);
   peer_t *U = user_chat_get (M->from_id);
   incomingMsg(M,(struct user*)U);
-  return;
   print_start ();
   push_color (COLOR_GREY);
 


### PR DESCRIPTION
Hello!

It seems there is a bug in Sigram. Whenever I click on a group chat in the left panel and right before all the conversations appear on the right panel the program crashes.

A quick debug reports that in interface.c:1202 incomingMsg is being called with U=0x0, this is, user_get_chat in the previous line returned 0. I guess this is an unexpected failure? Or should this case be treated separately? It seems those functions "do nothing useful", so I just removed the flow itself.

Thanks!
