### PR TITLE
Display emoji chars in group names. Solves issue #73

### DIFF
--- a/Sigram/ChatTitleBar.qml
+++ b/Sigram/ChatTitleBar.qml
@@ -72,7 +72,7 @@ Rectangle {
             anchors.horizontalCenter: column.horizontalCenter
             color: imageBack? "#333333" : "#bbbbbb"
             font.family: globalNormalFontFamily
-            text: Telegram.title(titlebar.current)
+            text: Emojis.textToEmojiText( Telegram.title(titlebar.current) )
         }
 
         Text {

--- a/Sigram/ContactListItem.qml
+++ b/Sigram/ContactListItem.qml
@@ -69,7 +69,7 @@ Rectangle {
 
                 Text {
                     id: txt
-                    text: item.isDialog ? Telegram.dialogTitle(dialog_id) : Telegram.contactTitle(item.uid)
+                    text: Emojis.textToEmojiText( item.isDialog ? Telegram.dialogTitle(dialog_id) : Telegram.contactTitle(item.uid) )
                     anchors.left: parent.left
                     width: parent.width - date.width - 18
                     font.pointSize: 10

--- a/Sigram/emojis.cpp
+++ b/Sigram/emojis.cpp
@@ -78,7 +78,6 @@ QString Emojis::currentTheme() const
 QString Emojis::textToEmojiText(const QString &txt)
 {
     QString res = txt.toHtmlEscaped();
-    Qt::LayoutDirection dir = TelegramGui::directionOf(txt);
 
     QRegExp links_rxp("((?:\\w\\S*\\/\\S*|\\/\\S+|\\:\\/)(?:\\/\\S*\\w|\\w\\/))");
     int pos = 0;
@@ -110,8 +109,7 @@ QString Emojis::textToEmojiText(const QString &txt)
         res = "<font size=\"1\">.</font>" + res;
 
 
-    QString dir_txt = dir==Qt::LeftToRight? "ltr" : "rtl";
-    res = QString("<html><body><p dir='%1'>").arg(dir_txt) + res.replace("\n","<br />") + "</p></body></html>";
+    res = res.replace("\n","<br />");
     return res;
 }
 


### PR DESCRIPTION
This commit allows to display emoji characters both in the left plane and in the tittle of the chat area.

I've removed most of the tags in the Emojis::textToEmojiText method in order to maintain the vertical alignment of the tittle in the chat area, along with the <p dir="..."> tag (this one inserted some unwanted vertical space). In my tests, the alignment is fine, but I may have broken something in RTL languages.
