### PR TITLE
Add missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Sigram project are released under the terms of the GPLv3 license.
 ### How to Compile
 #### Install dependencies
 
-Install gcc, g++, openssl, Qt5Core, Qt5DBus, Qt5Gui, Qt5Multimedia, Qt5MultimediaQuick_p, Qt5Network, Qt5PrintSupport, Qt5Qml, Qt5Quick, Qt5Sql, Qt5Svg, and Qt5Widgets.
+Install gcc, g++, openssl, Qt5Core, Qt5DBus, Qt5Gui, Qt5Multimedia, Qt5MultimediaQuick_p, Qt5Network, Qt5PrintSupport, Qt5Qml, Qt5Quick, Qt5Sql, Qt5Svg, Qt5Widgets, and libcurl4-openssl-dev.
 on Ubuntu:
 
-    sudo apt-get install g++ gcc qtbase5-dev libqt5sql5-sqlite libqt5multimediaquick-p5 libqt5multimedia5-plugins libqt5multimedia5 libqt5qml5 libqt5qml-graphicaleffects libqt5qml-quickcontrols qtdeclarative5-dev libqt5quick5 
+    sudo apt-get install g++ gcc qtbase5-dev libqt5sql5-sqlite libqt5multimediaquick-p5 libqt5multimedia5-plugins libqt5multimedia5 libqt5qml5 libqt5qml-graphicaleffects libqt5qml-quickcontrols qtdeclarative5-dev libqt5quick5 libcurl4-openssl-dev
 
 on Fedora (tested on Fedora 20):
 


### PR DESCRIPTION
I had a compilation error on Ubuntu due to missing "openssl/bn.h".
